### PR TITLE
Rename escaped keywords back with #[serde(rename)]

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -250,7 +250,7 @@ fn params(params: impl Iterator<Item = impl Borrow<crate::schema::Param>>) -> St
             let rename = if field.ends_with("_") {
                 format!("\n            #[serde(rename = \"{}\")]", &field[..field.len() - 1])
             } else {
-                "".to_string()
+                "".to_owned()
             };
             let convert = convert_for(ty);
             format!(

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -247,12 +247,18 @@ fn params(params: impl Iterator<Item = impl Borrow<crate::schema::Param>>) -> St
                 }
                 _ => "",
             };
+            let rename = if field.ends_with("_") {
+                format!("\n            #[serde(rename = \"{}\")]", &field[..field.len() - 1])
+            } else {
+                "".to_string()
+            };
             let convert = convert_for(ty);
             format!(
-                "        {doc}{flatten}{with}\n            pub {field}: {ty}{convert},",
+                "        {doc}{flatten}{with}{rename}\n            pub {field}: {ty}{convert},",
                 doc = doc,
                 flatten = flatten,
                 with = with,
+                rename = rename,
                 field = field,
                 ty = ty,
                 convert = convert

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -247,10 +247,9 @@ fn params(params: impl Iterator<Item = impl Borrow<crate::schema::Param>>) -> St
                 }
                 _ => "",
             };
-            let rename = if field.ends_with("_") {
-                format!("\n            #[serde(rename = \"{}\")]", &field[..field.len() - 1])
-            } else {
-                "".to_owned()
+            let rename = match field.strip_suffix('_') {
+                Some(field) => format!("\n            #[serde(rename = \"{}\")]", field),
+                None => "".to_owned(),
             };
             let convert = convert_for(ty);
             format!(


### PR DESCRIPTION
Closes #5